### PR TITLE
Add config option for gateway intents + cleaned up config handling

### DIFF
--- a/src/com/johnymuffin/discordcore/DiscordBot.java
+++ b/src/com/johnymuffin/discordcore/DiscordBot.java
@@ -1,6 +1,5 @@
 package com.johnymuffin.discordcore;
 
-import net.dv8tion.jda.api.AccountType;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.entities.TextChannel;
@@ -10,6 +9,7 @@ import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.utils.MemberCachePolicy;
 
 import javax.security.auth.login.LoginException;
+import java.util.ArrayList;
 import java.util.logging.Level;
 
 
@@ -22,8 +22,8 @@ public class DiscordBot extends ListenerAdapter {
         this.plugin = main;
     }
 
-    public void startBot(String token) throws LoginException {
-        jda = JDABuilder.createDefault(token).enableIntents(GatewayIntent.GUILD_MEMBERS).setMemberCachePolicy(MemberCachePolicy.ALL).build();
+    public void startBot(String token, ArrayList<GatewayIntent> intents) throws LoginException {
+        jda = JDABuilder.createDefault(token).enableIntents(intents).setMemberCachePolicy(MemberCachePolicy.ALL).build();
         jda.addEventListener(this);
 
     }

--- a/src/com/johnymuffin/discordcore/DiscordCore.java
+++ b/src/com/johnymuffin/discordcore/DiscordCore.java
@@ -10,6 +10,8 @@ import org.bukkit.util.config.Configuration;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -43,7 +45,7 @@ public class DiscordCore extends JavaPlugin implements Listener {
             return;
         }
 
-        ArrayList<String> rawIntentList = (ArrayList<String>) reduxConfig.getConfigOption("intents");
+        List<String> rawIntentList = reduxConfig.getStringList("intents", Arrays.asList("GUILD_MEMBERS", "DIRECT_MESSAGES", "MESSAGE_CONTENT"));
         ArrayList<GatewayIntent> intents = new ArrayList<>();
         for (String str : rawIntentList)
         {

--- a/src/com/johnymuffin/discordcore/DiscordCore.java
+++ b/src/com/johnymuffin/discordcore/DiscordCore.java
@@ -35,9 +35,9 @@ public class DiscordCore extends JavaPlugin implements Listener {
         reduxConfig = new ReduxConfig(new File(getDataFolder(), "config.yml"));
 
         //Config Information Start
-        String softToken = reduxConfig.getString("token", "NO_TOKEN_PROVIDED");
+        String softToken = reduxConfig.getString("token", "INSERT_TOKEN_HERE");
 
-        if(softToken == null || softToken.equalsIgnoreCase("token") || softToken.isEmpty()) {
+        if(softToken == null || softToken.equalsIgnoreCase("INSERT_TOKEN_HERE") || softToken.isEmpty()) {
             plugin.logInfo(Level.WARNING, "Failed to find a Discord token in the config file, shutting down.");
             Bukkit.getServer().getPluginManager().disablePlugin(plugin);
             return;

--- a/src/com/johnymuffin/discordcore/DiscordCore.java
+++ b/src/com/johnymuffin/discordcore/DiscordCore.java
@@ -1,5 +1,7 @@
 package com.johnymuffin.discordcore;
 
+import net.dv8tion.jda.api.requests.GatewayIntent;
+import net.oldschoolminecraft.discordcore.ReduxConfig;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.PluginDescriptionFile;
@@ -7,6 +9,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.util.config.Configuration;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -18,6 +21,7 @@ public class DiscordCore extends JavaPlugin implements Listener {
     private PluginDescriptionFile pdf;
     //Plugin Fields
     private DiscordBot discord;
+    private ReduxConfig reduxConfig;
 
 
     public void onEnable() {
@@ -28,28 +32,10 @@ public class DiscordCore extends JavaPlugin implements Listener {
         logInfo(Level.INFO, "Is Loading, Version: " + pdf.getVersion() + ".");
         logInfo(Level.INFO, "THIS PLUGIN IS LICENSED UNDER GNU.");
 
+        reduxConfig = new ReduxConfig(new File(getDataFolder(), "config.yml"));
+
         //Config Information Start
-        String softToken = null;
-        try {
-            File file = new File(plugin.getDataFolder(), "config.yml");
-            file.getParentFile().mkdirs();
-            Configuration configuration = new Configuration(file);
-            configuration.load();
-            if (configuration.getProperty("token") == null || configuration.getString("token").equalsIgnoreCase("token") || configuration.getString("token").isEmpty()) {
-                configuration.setProperty("token", "token");
-                configuration.save();
-                Bukkit.getServer().getPluginManager().disablePlugin(plugin);
-            } else {
-                softToken = (String) configuration.getProperty("token");
-            }
-        } catch (Exception e) {
-            try {
-                DCConfigReader dcConfigReader = new DCConfigReader(plugin);
-                softToken = dcConfigReader.getToken();
-            } catch (Exception e2) {
-                logInfo(Level.WARNING, "Unable to use backup ");
-            }
-        }
+        String softToken = reduxConfig.getString("token", "NO_TOKEN_PROVIDED");
 
         if(softToken == null || softToken.equalsIgnoreCase("token") || softToken.isEmpty()) {
             plugin.logInfo(Level.WARNING, "Failed to find a Discord token in the config file, shutting down.");
@@ -57,11 +43,25 @@ public class DiscordCore extends JavaPlugin implements Listener {
             return;
         }
 
+        ArrayList<String> rawIntentList = (ArrayList<String>) reduxConfig.getConfigOption("intents");
+        ArrayList<GatewayIntent> intents = new ArrayList<>();
+        for (String str : rawIntentList)
+        {
+            GatewayIntent intent = null;
+
+            try
+            {
+                intent = GatewayIntent.valueOf(str);
+            } catch (IllegalArgumentException ignored) {}
+
+            if (intent != null) intents.add(intent);
+        }
+
         //Config Information End
         logInfo(Level.INFO, "Starting internal Discord Bot.");
         try {
             discord = new DiscordBot(this);
-            discord.startBot(softToken);
+            discord.startBot(softToken, intents);
         } catch (Exception e) {
             logInfo(Level.WARNING, e + ": " + e.getMessage());
             Bukkit.getServer().getPluginManager().disablePlugin(plugin);

--- a/src/net/oldschoolminecraft/discordcore/ReduxConfig.java
+++ b/src/net/oldschoolminecraft/discordcore/ReduxConfig.java
@@ -1,0 +1,47 @@
+package net.oldschoolminecraft.discordcore;
+
+import org.bukkit.util.config.Configuration;
+
+import java.io.File;
+import java.util.Arrays;
+
+public class ReduxConfig extends Configuration
+{
+    public ReduxConfig(File file) {
+        super(file);
+        reload();
+    }
+
+    public void reload()
+    {
+        load();
+        write();
+        save();
+    }
+
+    private void write()
+    {
+        generateConfigOption("token", "INSERT_TOKEN_HERE");
+        generateConfigOption("intents", Arrays.asList("GUILD_MEMBERS", "DIRECT_MESSAGES", "MESSAGE_CONTENT"));
+    }
+
+    private void generateConfigOption(String key, Object defaultValue)
+    {
+        if (this.getProperty(key) == null) this.setProperty(key, defaultValue);
+        final Object value = this.getProperty(key);
+        this.removeProperty(key);
+        this.setProperty(key, value);
+    }
+
+    public Object getConfigOption(String key)
+    {
+        return this.getProperty(key);
+    }
+
+    public Object getConfigOption(String key, Object defaultValue)
+    {
+        Object value = getConfigOption(key);
+        if (value == null) value = defaultValue;
+        return value;
+    }
+}


### PR DESCRIPTION
I was thinking this would be nice, since accepting DMs requires having a specific gateway intent that isn't present by default. This new config handler should be backwards compatible with existing configurations since it doesn't change the token path, just adds a new list option for intents.

This PR also adds `DIRECT_MESSAGES` & `MESSAGE_CONTENT` as default gateway intents. If you don't think that should be included, I can change it back so it's just `GUILD_MEMBERS` as default.